### PR TITLE
Remove firebase dependency since we no longer use firebase

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,7 +3,6 @@
   "version": "0.1.0",
   "private": true,
   "dependencies": {
-    "firebase": "^5.11.1",
     "lodash": "^4.17.11",
     "react": "^16.12.0",
     "react-dom": "^16.12.0",


### PR DESCRIPTION
For some reason this package breaks in when being installed with yarn. This was never an issue before but recently netlify started defaulting to yarn instead of npm for codesandbox builds. This was causing students to suddenly be unable to deploy a live link of their projects. Removing the package fixes the issue